### PR TITLE
Added RockPro64 support for gubiq updates

### DIFF
--- a/gu.sh
+++ b/gu.sh
@@ -13,6 +13,8 @@ elif grep -q 'ODROID-C2' /proc/device-tree/model; then
 	hardware=OdroidC2
 elif grep -q 'Libre' /proc/device-tree/model; then
 	hardware=LibreLePotato
+elif grep -q 'RockPro64' /proc/device-tree/model; then
+	hardware=RockPro64
 fi
 
 sudo supervisorctl stop gubiq
@@ -23,7 +25,7 @@ if [ $hardware = RaspberryPi ] || [ $hardware = Tinkerboard ] || [ $hardware = O
 	wget https://github.com/ubiq/go-ubiq/releases/download/v5.2.1/gubiq-linux-arm7
   echo "cf1588a0d30eeb2a8a5339ab48248b04aef5dc148b6513aac26dd4da9fe29614 gubiq-linux-arm7" | sha256sum -c - || exit 1
 
-elif [ $hardware = OdroidC2 ] || [ $hardware = LibreLePotato ]; then
+elif [ $hardware = OdroidC2 ] || [ $hardware = LibreLePotato ] || [ $hardware = RockPro64 ]; then
 	sudo rm gubiq-linux-arm64
 	sudo rm /usr/bin/gubiq
 	wget https://github.com/ubiq/go-ubiq/releases/download/v5.2.1/gubiq-linux-arm64
@@ -32,7 +34,7 @@ fi
 
 if [ $hardware = RaspberryPi ] || [ $hardware = Tinkerboard ] || [ $hardware = OdroidXU4 ]; then
         sudo cp ./gubiq-linux-arm7 /usr/bin/gubiq
-elif [ $hardware = OdroidC2 ] || [ $hardware = LibreLePotato ]; then
+elif [ $hardware = OdroidC2 ] || [ $hardware = LibreLePotato ] || [ $hardware = RockPro64 ]; then
         sudo cp ./gubiq-linux-arm64 /usr/bin/gubiq
 fi
 


### PR DESCRIPTION
This makes it so you can use gu.sh on the RockPro64 compared to now where it just reboots without updating the gubiq binary.